### PR TITLE
Given key not present in dict fix.

### DIFF
--- a/cOverlay.cs
+++ b/cOverlay.cs
@@ -334,16 +334,18 @@ namespace cOverlay
 
                 foreach (var content in nodeContent)
                 {
+                    // Ensure content keys exist in dictionaries before accessing them
+                    if (!state.ContentCircleColor.ContainsKey(content.Name))
+                    {
+                        state.ContentCircleColor.Add(content.Name, Color.White);
+                    }
+                    if (!state.ContentToggle.ContainsKey(content.Name))
+                    {
+                        state.ContentToggle.Add(content.Name, false);
+                    }
+
                     if (contentSw.ElapsedMilliseconds > 10000)
                     {
-                        if (!state.ContentCircleColor.ContainsKey(content.Name))
-                        {
-                            state.ContentCircleColor.Add(content.Name, Color.White);
-                        }
-                        if (!state.ContentToggle.ContainsKey(content.Name))
-                        {
-                            state.ContentToggle.Add(content.Name, false);
-                        }
                         contentSw.Restart();
                     }
 


### PR DESCRIPTION
<img width="1288" height="227" alt="image" src="https://github.com/user-attachments/assets/438b5402-b6c8-4c22-bc3b-b28af617fbc4" />
Fix unsafe dictionary access in the DrawContent method. 