### PR TITLE
- Added Corrupted Nexus text with toggle.

### DIFF
--- a/SettingsClasses.cs
+++ b/SettingsClasses.cs
@@ -37,7 +37,8 @@ namespace cOverlay
             "Expedition",
             "Irradiated",
             "Map Boss",
-            "Delirium"
+            "Delirium",
+            "Corrupted Nexus"
         };
     }
 

--- a/cOverlayUI.cs
+++ b/cOverlayUI.cs
@@ -63,9 +63,9 @@ namespace cOverlay
             HelpMarker("How often new segments of atlas are updated. Default: 5000");
             ImGui.SliderInt("Screen refresh rate", ref state.screnRefreshRate, 100, 1000);
             HelpMarker("How often nodes on screen are updated. Default: 500");
-            ImGui.SliderInt("BorderX", ref state.borderX, 500, 2500);
+            ImGui.SliderInt("BorderX", ref state.borderX, 500, 5000);
             HelpMarker("X coordinate (from screen) bound where nodes are updated. Default: 1920");
-            ImGui.SliderInt("BorderY", ref state.borderY, 500, 1400);
+            ImGui.SliderInt("BorderY", ref state.borderY, 500, 5000);
             HelpMarker("Y coordinate (from screen) bound where nodes are updated. Default: 1080");
         }
 
@@ -95,6 +95,8 @@ namespace cOverlay
 
             ImGui.SeparatorText("Area text settings");
             ImGui.Checkbox("Enable corrupted maps counter (-1 of high towers amount)", ref state.ToggleCorruptedMaps);
+            ImGui.Checkbox("Show Corrupted Nexus", ref state.ToggleCorruptedNexus);
+            ImGui.Checkbox("Show all map content (ignore tower treshold)", ref state.ShowAllMapContent);
             ImGui.Checkbox("Recolor high towers amount", ref state.RecolorHighTowersAmount);
             ImGui.Checkbox("Draw towers range", ref state.DrawTowerRange);
             ImGui.Checkbox("Show towers amount after name [1/5]", ref state.showTowersAtName);


### PR DESCRIPTION
- Introduced a new checkbox for showing Corrupted Nexus in the UI.
- Added a new boolean property to manage visibility of all map content.
- Added map content is enabled automatically now, can be toggled in Content settings.
- Updated border dimensions in settings to accommodate higher resolutions and made the default border 1920x1080.
- Implemented area color generation based on area names for better visual distinction.
- Adjusted the high tower amount threshold and related settings for improved gameplay experience.
- Fixed issue when running the plugin and StateSettings.json does not exist, file is now created and the file stream is immediately disposed to prevent file being locked.
- Initialized some dictionaries fixing a problem where map content was sometimes not being added correctly.
- Fixed issue with text color configured for items under Content settings was not working due to being overriden by transversable text, it now uses the color defined and applies transparency is the node is not transversable.